### PR TITLE
Simplified the configuration using a single 'config' key in DI container

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,21 +47,42 @@ $builder = new ContainerBuilder();
 $builder->addDefinitions('config/container.php');
 $container = $builder->build();
 
-$app = new App($container, require 'config/app.php');
-$app->bootstrap();
+$app = new App($container);
+$app->bootstrap(); // optional
 $response = $app->dispatch(); // PSR-7 response
 
 SapiEmitter::emit($response);
 ```
 
 In this example we use a DI container with [PHP-DI](https://php-di.org/). We create a `SimpleMVC\App` object
-using the previous container and a configuration array. Then we `bootstrap()` the application and we `dispatch()`
-the request. The PSR-7 response is stored in a `$response` variable that can be rendered using a
-`SimpleMVC\Emitter\EmitterIntarfce`.
+using the previous container. 
 
+The application can be configured using the `config/container.php` file. An example is as follows:
+
+```php
+// config/container.php
+use App\Controller;
+
+return [
+    'config' => [
+        'routing' => [
+            'routes' => [
+                [ 'GET', '/', Controller\HomePage::class ]
+            ]
+        ]
+    ]
+];
+```
+
+The steps to manage the request are:
+
+- `bootstrap()` (optional), here you can specify any bootstrap requirements;
+- `dispatch()`, where the HTTP request is dispatched, executing the controller specified in the route.
+
+The `dispatch()` returns a PSR-7 response. Finally, we can render the response using an emitter.
 In this example we used a `SapiEmitter` to render the PSR-7 response in the standard output.
 
-This example acts as a front controller of an MVC application (see diagram below).
+The previous PHP script is basically a front controller of an MVC application (see diagram below).
 
 ![MVC diagram](doc/mvc.png)
 

--- a/src/App.php
+++ b/src/App.php
@@ -38,6 +38,7 @@ class App
     private ContainerInterface $container;
     private LoggerInterface $logger;
     private float $startTime;
+    
     /** @var mixed[] */
     private array $config;
 
@@ -130,7 +131,7 @@ class App
         if (isset($this->config['bootstrap'])) {
             $start = microtime(true);
             $this->config['bootstrap']($this->container);
-            $this->logger->info(sprintf("Bootstrap execution: %.3f sec", microtime(true) - $start));
+            $this->logger->debug(sprintf("Bootstrap execution: %.3f sec", microtime(true) - $start));
         }
     }
 
@@ -167,13 +168,13 @@ class App
 
         $controllerName = is_array($controllerName) ?: [$controllerName];
         foreach ($controllerName as $controller) {
-            $this->logger->info(sprintf("Executing %s", $controller));
+            $this->logger->debug(sprintf("Executing %s", $controller));
             try {
                 $response = $this->container
                     ->get($controller)
                     ->execute($this->request, $response);
                 if ($response instanceof HaltResponse) {
-                    $this->logger->info(sprintf("Found HaltResponse in %s", $controller));
+                    $this->logger->debug(sprintf("Found HaltResponse in %s", $controller));
                     break;
                 }
             } catch (NotFoundExceptionInterface $e) {

--- a/src/App.php
+++ b/src/App.php
@@ -16,6 +16,7 @@ use Nyholm\Psr7\Factory\Psr17Factory;
 use Nyholm\Psr7\Response;
 use Nyholm\Psr7Server\ServerRequestCreator;
 use Psr\Container\ContainerInterface;
+use Psr\Container\NotFoundExceptionInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Log\LoggerInterface;
@@ -30,52 +31,56 @@ use function FastRoute\cachedDispatcher;
 
 class App
 {
-    const VERSION = '0.1';
+    const VERSION = '0.1.1';
 
     private Dispatcher $dispatcher;
     private ServerRequestInterface $request;
     private ContainerInterface $container;
     private LoggerInterface $logger;
     private float $startTime;
+    /** @var mixed[] */
+    private array $config;
 
-    /**
-     * @var mixed[]
-     */
-    private $config;
-
-    /**
-     * @param mixed[] $config
-     */
-    public function __construct(ContainerInterface $container, array $config)
+    public function __construct(ContainerInterface $container)
     {
         $this->startTime = microtime(true);
-        $this->container = $container;
-        $this->config    = $config;        
+        $this->container = $container;    
 
-        // Routing initialization
-        if (!isset($config['routing']['routes'])) {
+        try {
+            $this->config = $container->get('config');
+        } catch (NotFoundExceptionInterface $e) {
             throw new InvalidConfigException(
-                'You need to provide a [\'routing\'][\'routes\'] value in configuration'
+                'The configuation is missing! Be sure to have a "config" key in the container'
             );
         }
-        $this->dispatcher = cachedDispatcher(function(RouteCollector $r) use ($config) {
-            foreach ($config['routing']['routes'] as $route) {
+        if (!isset($this->config['routing']['routes'])) {
+            throw new InvalidConfigException(
+                'The ["routing"]["routes"] is missing in configuration'
+            );
+        }
+        $routes = $this->config['routing']['routes'];
+        // Routing initialization
+        $this->dispatcher = cachedDispatcher(function(RouteCollector $r) use ($routes) {
+            foreach ($routes as $route) {
                 $r->addRoute($route[0], $route[1], $route[2]);
             }
         }, [
-            'cacheFile'     => $config['routing']['cache'] ?? '',
-            'cacheDisabled' => !isset($config['routing']['cache'])
+            'cacheFile'     => $this->config['routing']['cache'] ?? '',
+            'cacheDisabled' => !isset($this->config['routing']['cache'])
         ]);
 
         // Logger initialization
-        if (isset($config['logger']) && !($config['logger'] instanceof LoggerInterface)) {
-            throw new InvalidConfigException(sprintf(
-                "The logger must implement %s'",
-                LoggerInterface::class
-            ));
+        try {
+            $this->logger = $container->get(LoggerInterface::class);
+        } catch (NotFoundExceptionInterface $e) {
+            $this->logger = new NullLogger();
         }
-        $this->logger = $config['logger'] ?? new NullLogger();
 
+        if (isset($this->config['bootstrap']) && !is_callable($this->config['bootstrap'])) {
+            throw new InvalidConfigException('The ["bootstrap"] must a callable');
+        }
+
+        // Build the PSR-7 request
         $f = new Psr17Factory();
         $this->request = (new ServerRequestCreator($f, $f, $f, $f))->fromGlobals();
         
@@ -87,13 +92,8 @@ class App
     }
 
     /**
-     * @return mixed[]
+     * Returns the PSR-7 request
      */
-    public function getConfig(): array
-    {
-        return $this->config;
-    }
-
     public function getRequest(): ServerRequestInterface
     {
         return $this->request;
@@ -104,6 +104,19 @@ class App
         return $this->container;
     }
 
+    public function getDispatcher(): Dispatcher
+    {
+        return $this->dispatcher;
+    }
+    
+    /**
+     * @return mixed[]
+     */
+    public function getConfig(): array
+    {
+        return $this->config;
+    }
+
     public function getLogger(): LoggerInterface
     {
         return $this->logger;
@@ -111,14 +124,9 @@ class App
 
     public function bootstrap(): void
     {
-        // Initialize custom bootstrap, if any
-        $bootstrap = $this->config['bootstrap'] ?? null;
-        if (null !== $bootstrap && !is_callable($bootstrap)) {
-            throw new InvalidConfigException('The bootstrap config value must be a callable!');
-        }
-        if (null !== $bootstrap) {
+        if (isset($this->config['bootstrap'])) {
             $start = microtime(true);
-            $bootstrap($this->container);
+            $this->config['bootstrap']($this->container);
             $this->logger->info(sprintf("Bootstrap execution: %.3f sec", microtime(true) - $start));
         }
     }
@@ -133,11 +141,11 @@ class App
         switch ($routeInfo[0]) {
             case Dispatcher::NOT_FOUND:
                 $this->logger->warning('Controller not found (404)');
-                $controllerName = $this->config['error']['404'] ?? Error404::class;
+                $controllerName = $this->config['errors']['404'] ?? Error404::class;
                 break;
             case Dispatcher::METHOD_NOT_ALLOWED:
                 $this->logger->warning('Method not allowed (405)');
-                $controllerName = $this->config['error']['405'] ?? Error405::class;
+                $controllerName = $this->config['errors']['405'] ?? Error405::class;
                 break;
             case Dispatcher::FOUND:
                 $controllerName = $routeInfo[1];
@@ -153,23 +161,31 @@ class App
 
         if (is_string($controllerName)) {
             $this->logger->info(sprintf("Executing %s", $controllerName));
-            $controller = $this->container->get($controllerName);
-            if (empty($controller)) {
+            try {
+                $controller = $this->container->get($controllerName);
+                $response = $controller->execute($this->request, $response);  
+            } catch (NotFoundExceptionInterface $e) {
                 throw new ControllerException(sprintf(
                     'The controller name %s cannot be retrieved from the container',
                     $controllerName
                 ));
-            }
-            $response = $controller->execute($this->request, $response);    
+            }  
         } elseif (is_array($controllerName)) {
             foreach ($controllerName as $controller) {
                 $this->logger->info(sprintf("Executing %s", $controller));
-                $response = $this->container
-                    ->get($controller)
-                    ->execute($this->request, $response);
-                if ($response instanceof HaltResponse) {
-                    $this->logger->info(sprintf("Found HaltResponse in %s", $controller));
-                    break;
+                try {
+                    $response = $this->container
+                        ->get($controller)
+                        ->execute($this->request, $response);
+                    if ($response instanceof HaltResponse) {
+                        $this->logger->info(sprintf("Found HaltResponse in %s", $controller));
+                        break;
+                    }
+                } catch (NotFoundExceptionInterface $e) {
+                    throw new ControllerException(sprintf(
+                        'The controller name %s cannot be retrieved from the container',
+                        $controller
+                    ));
                 }    
             }
         } else {

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -10,12 +10,17 @@ declare(strict_types=1);
 
 namespace SimpleMVC\Test;
 
+use Exception;
+use FastRoute\Dispatcher;
 use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Rule\AnyInvokedCount;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
+use Psr\Container\NotFoundExceptionInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 use SimpleMVC\App;
 use SimpleMVC\Controller\Error404;
 use SimpleMVC\Exception\InvalidConfigException;
@@ -25,40 +30,107 @@ class AppTest extends TestCase
     /** @var ContainerInterface|MockObject */
     private $container;
 
-    private App $app;
+    private string $tmpCacheFile;
 
     /** @var mixed[] */
     private array $config;
 
+    private AnyInvokedCount $matcher;
+
     public function setUp(): void
     {
+        $this->tmpCacheFile = sys_get_temp_dir() . '/cache.route';
         $this->config = [ 
             'routing' => [
                 'routes' => []
             ]
         ];
         $this->container = $this->createMock(ContainerInterface::class);
-        $this->app = new App($this->container, $this->config);
+        $this->matcher = $this->any();
+        $this->container
+            ->expects($this->matcher)
+            ->method('get')
+            ->withConsecutive(['config'], [LoggerInterface::class])
+            ->willReturnCallback(function() {
+                switch($this->matcher->getInvocationCount()) {
+                    case 1:
+                        return $this->config;
+                    case 2:
+                        throw new class extends Exception implements NotFoundExceptionInterface {};
+                    case 3:
+                        return new Error404();
+                }
+            });
+    }
+
+    public function tearDown(): void
+    {
+        if (file_exists($this->tmpCacheFile)) {
+            unlink($this->tmpCacheFile);
+        }
     }
 
     public function testGetContainer(): void
     {
-        $this->assertInstanceOf(ContainerInterface::class, $this->app->getContainer());
-    }
-
-    public function testGetConfig(): void
-    {
-        $this->assertEquals($this->config, $this->app->getConfig());
+        $app = new App($this->container);
+        $this->assertInstanceOf(ContainerInterface::class, $app->getContainer());
+        $this->assertEquals($this->container, $app->getContainer());
     }
 
     public function testGetLogger(): void
     {
-        $this->assertInstanceOf(LoggerInterface::class, $this->app->getLogger());
+        $app = new App($this->container);
+        $this->assertInstanceOf(LoggerInterface::class, $app->getLogger());
+    }
+
+    public function testGetDefaultNullLogger(): void
+    {
+        $app = new App($this->container);
+        $this->assertInstanceOf(NullLogger::class, $app->getLogger());
+    }
+
+    public function testUseCustomLogger(): void
+    {
+        $customLogger = new class extends NullLogger {};
+        $container = $this->createMock(ContainerInterface::class);
+        $container->expects($this->matcher)
+            ->method('get')
+            ->withConsecutive(['config'], [LoggerInterface::class])
+            ->willReturnCallback(function() use ($customLogger) {
+                switch($this->matcher->getInvocationCount()) {
+                    case 1:
+                        return $this->config;
+                    case 2:
+                        return $customLogger;
+                }
+        });
+        $app = new App($container);
+        $this->assertEquals($customLogger, $app->getLogger());
+    }
+
+    public function testGetConfig(): void
+    {
+        $app = new App($this->container);
+        $this->assertEquals($this->config, $app->getConfig());
+    }
+
+    public function testGetDispatcher(): void
+    {
+        $app = new App($this->container);
+        $this->assertInstanceOf(Dispatcher::class, $app->getDispatcher());
+    }
+
+    public function testEnableCacheForRouting(): void
+    {
+        $this->config['routing']['cache'] = $this->tmpCacheFile;
+        $app = new App($this->container);
+        $this->assertFileExists($this->tmpCacheFile);
     }
 
     public function testGetRequest(): void
     {
-        $this->assertInstanceOf(RequestInterface::class, $this->app->getRequest());
+        $app = new App($this->container);
+        $this->assertInstanceOf(RequestInterface::class, $app->getRequest());
     }
 
     /**
@@ -66,7 +138,8 @@ class AppTest extends TestCase
      */
     public function testBootstrapWithEmptyValue(): void
     {
-        $this->app->bootstrap();
+        $app = new App($this->container);
+        $app->bootstrap();
     }
 
     public function testBootstrapWithClosure(): void
@@ -74,25 +147,22 @@ class AppTest extends TestCase
         $this->config['bootstrap'] = function(ContainerInterface $c) {
             $this->assertInstanceOf(ContainerInterface::class, $c);
         };
-        $this->app = new App($this->container, $this->config);
-        $this->app->bootstrap();
+        $app = new App($this->container);
+        $app->bootstrap();
     }
 
     public function testBootstrapWithNoCallable(): void
     {
         $this->config['bootstrap'] = 'test';
-        $this->app = new App($this->container, $this->config);
         $this->expectException(InvalidConfigException::class);
-        $this->app->bootstrap();
+        $app = new App($this->container);
     }
 
     public function testDispatch(): void
     {
-        $this->container->method('get')
-            ->with($this->equalTo('SimpleMVC\Controller\Error404'))
-            ->willReturn(new Error404);
+        $app = new App($this->container);
+        $response = $app->dispatch();
 
-        $response = $this->app->dispatch();
         $this->assertInstanceOf(ResponseInterface::class, $response);
         $this->assertEquals(404, $response->getStatusCode());            
     }


### PR DESCRIPTION
This PR simplify the configuration process using only one `config` key in the DI container.
This can be useful also for retrieving the configuration in any Controller, injecting just the DI container instance.

An example of configuration is as follows, I used 2 files for the general application configuration (`config.php`) and for the DI container (`container.php`):
```php
// config/config.php
use App\Controller;
return [
    'routing' => [
        'routes => [
            [ 'GET', '/', Controller\HomePage::class ]
        ]
    ],
    'pdo_dsn' => 'sqlite:data/db.sqlite'
];
```
```php
// config/container.php
use PDO;
use Psr\Container\ContainerInterface;
return [
    'config' => require 'config.php',
    // specific DI configurations (eg. PDO)
    PDO::class => function(ContainerInterface $c) {
        return new PDO($c->get('config')["pdo_dsn"]);
    }
];
```
In this way we just need to pass the `config/container.php` file to the DI container.
For instance, using PHP-DI we can use the following code:
```php
use DI\ContainerBuilder;
use SimpleMVC\App;

$builder = new ContainerBuilder();
$builder->addDefinitions('config/container.php');
$container = $builder->build();
$app = new App($container);
```
